### PR TITLE
Fix cmath include in color.cpp

### DIFF
--- a/src/util/color.cpp
+++ b/src/util/color.cpp
@@ -20,7 +20,7 @@
 
 #include "util/color.h"
 
-#include <cmath.h>
+#include <cmath>
 #include <Imath/half.h>
 #include <math.h>
 #include <stdint.h>


### PR DESCRIPTION
Hi there. I'm trying to write a nix flake for olive 0.2.
It currently fails because of cmath.h not being found.
However, if I replace `<cmath.h>` with `<cmath>` in `src/util/color.cpp` it seems to fix it.
Seems to be an issue on Arch Linux as well and not just with nix.
